### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ A simple implementation of the observer pattern.
 	# -> AssertionError: snorble is not a valid event for this subject
 
 
-.. |PyPI| image:: https://pypip.in/version/simpleobserver/badge.svg?style=flat
+.. |PyPI| image:: https://img.shields.io/pypi/v/simpleobserver.svg?style=flat
    :target: https://pypi.python.org/pypi/simpleobserver/
 
 .. |Build Status| image:: https://travis-ci.org/cooper-software/simpleobserver.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20observer-simple))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `observer-simple`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.